### PR TITLE
bc - added menu option for search by instructor

### DIFF
--- a/.github/workflows/33-frontend-pr-mutation-testing.yml
+++ b/.github/workflows/33-frontend-pr-mutation-testing.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 240
     env:
       destination: frontend/reports/mutation
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# proj-courses
+# proj-courses-s23-7pm-1
 
 This repo contains the code for the CMPSC 156 legacy code project "Courses Search". 
 
@@ -10,8 +10,8 @@ Users with a Google Account can also store past, current or future schedules of 
 
 | Type | Link       | 
 |------|------------|
-| prod | <https://proj-courses.dokku-00.cs.ucsb.edu/> | 
-| qa | <https://proj-courses-qa.dokku-00.cs.ucsb.edu/>  | 
+| prod | <https://proj-courses.dokku-09.cs.ucsb.edu/> | 
+| qa | <https://proj-courses-qa.dokku-09.cs.ucsb.edu/>  | 
 
 
 # Setup before running application

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -21,7 +21,7 @@ import CoursesIndexPage from "main/pages/Courses/PSCourseIndexPage";
 import CoursesCreatePage from "main/pages/Courses/PSCourseCreatePage";
 
 import CourseOverTimeIndexPage from "main/pages/CourseOverTime/CourseOverTimeIndexPage";
-
+import CourseInstructorIndexPage from "main/pages/CourseInstructor/CourseInstructorIndexPage";
 function App() {
 
   const { data: currentUser } = useCurrentUser();
@@ -56,6 +56,7 @@ function App() {
         }
         <Route exact path="/coursedescriptions/search" element={<CourseDescriptionIndexPage />} />
         <Route exact path="/courseovertime/search" element={<CourseOverTimeIndexPage />} />
+        <Route exact path="/courseinstructor/search" element={<CourseInstructorIndexPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -84,7 +84,11 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               </NavDropdown>
             </Nav>
 
-
+            <Nav className="mr-auto">
+              <NavDropdown title="Course Instructor" id="appnavbar-course-instructor-dropdown" data-testid="appnavbar-course-instructor-dropdown" >
+                <NavDropdown.Item href="/courseinstructor/search" data-testid="appnavbar-course-instructor-search">Search</NavDropdown.Item>
+              </NavDropdown>
+            </Nav>
             
             <Nav className="mr-auto">
               {

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -73,20 +73,14 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
             </Nav>
 
             <Nav className="mr-auto">
-              <NavDropdown title="Course Descriptions" id="appnavbar-course-descriptions-dropdown" data-testid="appnavbar-course-descriptions-dropdown" >
-                <NavDropdown.Item href="/coursedescriptions/search" data-testid="appnavbar-course-descriptions-search">Search</NavDropdown.Item>
-              </NavDropdown>
+              <Nav.Link href="/coursedescriptions/search" data-testid="appnavbar-course-descriptions-search">Course Descriptions</Nav.Link>  
             </Nav>
 
-            <Nav className="mr-auto">
-              <NavDropdown title="Course History" id="appnavbar-course-over-time-dropdown" data-testid="appnavbar-course-over-time-dropdown" >
-                <NavDropdown.Item href="/courseovertime/search" data-testid="appnavbar-course-over-time-search">Search</NavDropdown.Item>
-              </NavDropdown>
-            </Nav>
 
             <Nav className="mr-auto">
-              <NavDropdown title="Course Instructor" id="appnavbar-course-instructor-dropdown" data-testid="appnavbar-course-instructor-dropdown" >
-                <NavDropdown.Item href="/courseinstructor/search" data-testid="appnavbar-course-instructor-search">Search</NavDropdown.Item>
+              <NavDropdown title="Search By" id="appnavbar-searcb-by-dropdown" data-testid="appnavbar-search-by-dropdown" >
+                <NavDropdown.Item href="/courseovertime/search" data-testid="appnavbar-course-over-time-search">Course History</NavDropdown.Item>
+                <NavDropdown.Item href="/courseinstructor/search" data-testid="appnavbar-course-instructor-search">Course Instructor</NavDropdown.Item>
               </NavDropdown>
             </Nav>
             

--- a/frontend/src/main/pages/CourseInstructor/CourseInstructorIndexPage.js
+++ b/frontend/src/main/pages/CourseInstructor/CourseInstructorIndexPage.js
@@ -1,0 +1,13 @@
+
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function CourseInstructorIndexPage() {
+  
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h5>Course Instructor Search Feature Coming Soon!</h5>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -192,7 +192,7 @@ describe("AppNavbar tests", () => {
         expect(screen.getByTestId(/appnavbar-personalschedules-create/)).toBeInTheDocument();
     });
 
-    test("renders the Course Description menu correctly", async () => {
+    test("renders the Course Description link correctly", async () => {
         const currentUser = currentUserFixtures.userOnly;
         const systemInfo = systemInfoFixtures.showingBoth;
 
@@ -206,13 +206,8 @@ describe("AppNavbar tests", () => {
             </QueryClientProvider>
         );
 
-        expect(await screen.findByTestId("appnavbar-course-descriptions-dropdown")).toBeInTheDocument();
-        const dropdown = screen.getByTestId("appnavbar-course-descriptions-dropdown");
-        const aElement = dropdown.querySelector("a");
-        expect(aElement).toBeInTheDocument();
-        aElement?.click();
-
-        expect(await screen.findByTestId("appnavbar-course-descriptions-search")).toBeInTheDocument();
+        expect(await screen.findByText("Course Descriptions")).toBeInTheDocument();
+        
     });
 
     test("renders the Course History/Course Over Time menu correctly", async () => {
@@ -229,8 +224,8 @@ describe("AppNavbar tests", () => {
             </QueryClientProvider>
         );
 
-        expect(await screen.findByTestId("appnavbar-course-over-time-dropdown")).toBeInTheDocument();
-        const dropdown = screen.getByTestId("appnavbar-course-over-time-dropdown");
+        expect(await screen.findByTestId("appnavbar-search-by-dropdown")).toBeInTheDocument();
+        const dropdown = screen.getByTestId("appnavbar-search-by-dropdown");
         const aElement = dropdown.querySelector("a");
         expect(aElement).toBeInTheDocument();
         aElement?.click();

--- a/frontend/src/tests/pages/CourseInstructor/CourseInstructorIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseInstructor/CourseInstructorIndexPage.test.js
@@ -1,14 +1,14 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import userEvent from "@testing-library/user-event";
+
 
 import CourseInstructorIndexPage from "main/pages/CourseInstructor/CourseInstructorIndexPage";
-import { coursesFixtures } from "fixtures/courseFixtures";
+
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
-import { allTheSubjects } from "fixtures/subjectFixtures";
+
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 const mockToast = jest.fn();

--- a/frontend/src/tests/pages/CourseInstructor/CourseInstructorIndexPage.test.js
+++ b/frontend/src/tests/pages/CourseInstructor/CourseInstructorIndexPage.test.js
@@ -1,0 +1,54 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import userEvent from "@testing-library/user-event";
+
+import CourseInstructorIndexPage from "main/pages/CourseInstructor/CourseInstructorIndexPage";
+import { coursesFixtures } from "fixtures/courseFixtures";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { allTheSubjects } from "fixtures/subjectFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+
+const mockToast = jest.fn();
+jest.mock("react-toastify", () => {
+  const originalModule = jest.requireActual("react-toastify");
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+describe("CourseInstructorIndexPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  beforeEach(() => {
+    jest.spyOn(console, 'error')
+    console.error.mockImplementation(() => null);
+  });
+
+  beforeEach(() => {
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  });
+
+  const queryClient = new QueryClient();
+  test("renders without crashing", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <CourseInstructorIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  });
+
+  
+});


### PR DESCRIPTION
This PR updates the NavBar.
It changes the course description dropdown into just a single link to the course description search. 
It removes the dropdown for course history, and instead adds a new dropdown called search by which contains two links, one to lead to course history search and one that leads to course instructor search.
Form for course instructor search coming later.

StoryBook:
[Before](https://ucsb-cs156-s23.github.io/proj-courses-s23-7pm-1/storybook/?path=/docs/components-nav-appnavbar--basic-not-logged-in)
[After](https://ucsb-cs156-s23.github.io/proj-courses-s23-7pm-1/prs/29/storybook/?path=/docs/components-nav-appnavbar--basic-not-logged-in)

Screenshots:

Before:
<img width="515" alt="Screenshot 2023-05-29 at 11 36 43 PM" src="https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-1/assets/122656360/06f627df-4873-47fe-89d6-d3cecd855026">

After:
<img width="765" alt="Screenshot 2023-05-31 at 7 50 52 PM" src="https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-1/assets/122656360/d4ef1ca5-210e-445b-9804-d570ed665dbe">

