### PR TITLE
pc - update workflows 12 and 13 to publish to github pages

### DIFF
--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -26,32 +26,31 @@ jobs:
          java-version-file: ./.java-version
   
     - name: Build with Maven
-      env:
-        TEST_PROPERTIES: ${{ secrets.TEST_PROPERTIES }}
       run: mvn -B test jacoco:report verify
 
     - name: Get PR number
       id: get-pr-num
       run: |
-         echo "GITHUB_EVENT_PATH=${GITHUB_EVENT_PATH}"
-         pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
-         echo "pr_number=${pr_number}" 
-         echo "pr_number=${pr_number}" >> "$GITHUB_ENV"
+        echo "GITHUB_EVENT_PATH=${GITHUB_EVENT_PATH}"
+        pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+        echo "pr_number=${pr_number}" 
+        if [[ "${pr_number}" == "null" ]]; then
+          echo "This is not a PR"
+          pr_number="main"
+        fi
+        echo "pr_number=${pr_number}" >> "$GITHUB_ENV"
 
     - name: Set path for github pages deploy when there is a PR num
-      if: ${{ env.pr_number != 'null' }}
+      if: always() # always upload artifacts, even if tests fail
       run: |
-        prefix="prs/${pr_number}/"
+        if [ "${{env.pr_number }}" = "main" ]; then
+            prefix=""
+        else
+            prefix="prs/${{ env.pr_number }}/"
+        fi
         echo "prefix=${prefix}"
         echo "prefix=${prefix}" >> "$GITHUB_ENV"
-    
-    - name: Set path for github pages deploy when there is NOT a PR num
-      if: ${{ env.pr_number == 'null' }}
-      run: |
-        prefix=""
-        echo "prefix=${prefix}"
-        echo "prefix=${prefix}" >> "$GITHUB_ENV"
-    
+      
     - name: Deploy 🚀
       uses: JamesIves/github-pages-deploy-action@v4
       with:

--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -29,6 +29,7 @@ jobs:
       run: mvn -B test jacoco:report verify
 
     - name: Get PR number
+      if: always() # always upload artifacts, even if tests fail
       id: get-pr-num
       run: |
         echo "GITHUB_EVENT_PATH=${GITHUB_EVENT_PATH}"

--- a/.github/workflows/12-backend-jacoco.yml
+++ b/.github/workflows/12-backend-jacoco.yml
@@ -6,11 +6,10 @@ name: "12-backend-jacoco: Java Test Coverage (Jacoco)"
 on:
   workflow_dispatch:
   pull_request:
-    paths: [src/**, pom.xml, lombok.config]
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/12-backend-jacoco.yml]
   push:
     branches: [ main ]
-    paths: [src/**, pom.xml, lombok.config]
-
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/12-backend-jacoco.yml]
 
 jobs:
   build-jacoco-report:

--- a/.github/workflows/13-backend-incremental-pitest.yml
+++ b/.github/workflows/13-backend-incremental-pitest.yml
@@ -6,10 +6,10 @@ name: "13-backend-incremental-pitest: Java Mutation Testing (Pitest)"
 on:
   workflow_dispatch:
   pull_request:
-    paths: [src/**, pom.xml, lombok.config]
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/13-backend-incremental-pitest.yml]
   push:
     branches: [ main ]
-    paths: [src/**, pom.xml, lombok.config]
+    paths: [src/**, pom.xml, lombok.config, .github/workflows/13-backend-incremental-pitest.yml]
 
 jobs:
   build:

--- a/.github/workflows/13-backend-incremental-pitest.yml
+++ b/.github/workflows/13-backend-incremental-pitest.yml
@@ -29,7 +29,12 @@ jobs:
         echo "GITHUB_EVENT_PATH=${GITHUB_EVENT_PATH}"
         pr_number=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
         echo "pr_number=${pr_number}" 
+        if [[ "${pr_number}" == "null" ]]; then
+          echo "This is not a PR"
+          pr_number="main"
+        fi
         echo "pr_number=${pr_number}" >> "$GITHUB_ENV"
+           
     - name: Figure out branch name
       id: get-branch-name
       run: | 
@@ -76,21 +81,17 @@ jobs:
         name: pitest
         path: target/pit-reports/* 
 
-
     - name: Set path for github pages deploy when there is a PR num
-      if: ${{ env.pr_number != 'null' }}
+      if: always() # always upload artifacts, even if tests fail
       run: |
-        prefix="prs/${pr_number}/"
+        if [ "${{env.pr_number }}" = "main" ]; then
+            prefix=""
+        else
+            prefix="prs/${{ env.pr_number }}/"
+        fi
         echo "prefix=${prefix}"
         echo "prefix=${prefix}" >> "$GITHUB_ENV"
-    
-    - name: Set path for github pages deploy when there is NOT a PR num
-      if: ${{ env.pr_number == 'null' }}
-      run: |
-        prefix=""
-        echo "prefix=${prefix}"
-        echo "prefix=${prefix}" >> "$GITHUB_ENV"
-
+      
     - name: Deploy 🚀
       if: always() # always upload artifacts, even if tests fail
       uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/33-frontend-pr-mutation-testing.yml
+++ b/.github/workflows/33-frontend-pr-mutation-testing.yml
@@ -8,7 +8,7 @@ name: "33-frontend-pr-mutation-testing: Stryker JS Mutation Testing (JavaScript/
 on:
   workflow_dispatch:
   pull_request:
-    paths: [frontend/**]
+    paths: [frontend/**, .github/workflows/33-frontend-pr-mutation-testing.yml]
 
 jobs:
   build:


### PR DESCRIPTION
This fixes some errors in the coding that were leading the jacoco and pitest results for PRs to not show up on the Github Pages site properly.

* Before: The links in table below for PRs in the jacoco and pitest column do not reliably lead to a report
* After: They do reliably lead to a report, even when the jacoco or pitest result is that coverage is below the stated threshold.

<img width="708" alt="image" src="https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-1/assets/1119017/3dde4790-5ca6-4535-be59-03b5ab2d6eb9">
 