### PR TITLE
Upload Grade History Data Job and Factory 

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UploadGradeDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UploadGradeDataJob.java
@@ -1,0 +1,66 @@
+package edu.ucsb.cs156.courses.jobs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.ucsb.cs156.courses.entities.GradeHistory;
+import edu.ucsb.cs156.courses.repositories.GradeHistoryRepository;
+import edu.ucsb.cs156.courses.services.UCSBGradeHistoryService;
+import edu.ucsb.cs156.courses.services.jobs.JobContext;
+import edu.ucsb.cs156.courses.services.jobs.JobContextConsumer;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+public class UploadGradeDataJob implements JobContextConsumer {
+    @Getter
+    private UCSBGradeHistoryService ucsbGradeHistoryService;
+    @Getter
+    private GradeHistoryRepository gradeHistoryRepository;
+
+    @Override
+    public void accept(JobContext ctx) throws Exception {
+        ctx.log("Updating UCSB Grade History Data");
+        List<String> urls = ucsbGradeHistoryService.getUrls();
+
+        GradeHistory previous = new GradeHistory();
+        List<GradeHistory> results = null;
+        for (String url : urls) {
+            results = ucsbGradeHistoryService.getGradeData(url);
+            GradeHistory topRow = results.get(0);
+            upsertAll(gradeHistoryRepository, results);
+            logProgress(ctx, topRow, previous);
+        }
+
+        ctx.log("Finished updating UCSB Grade History Data");
+    }
+
+    private void logProgress(JobContext ctx, GradeHistory topRow, GradeHistory previous) {
+        if (!topRow.getYyyyq().equals(previous.getYyyyq())) {
+            ctx.log("Processing data for year: " + topRow.getYyyyq());
+            previous.setYyyyq(topRow.getYyyyq());
+        }
+        ctx.log("Processing data for subjectArea: " + topRow.getSubjectArea());
+    }
+
+    public static List<GradeHistory> upsertAll(
+            GradeHistoryRepository gradeHistoryRepository,
+            List<GradeHistory> gradeHistories) {
+        List<GradeHistory> result = new ArrayList<GradeHistory>();
+        for (GradeHistory gradeHistory : gradeHistories) {
+            List<GradeHistory> query = gradeHistoryRepository.findByYyyyqAndCourseAndInstructorAndGrade(
+                    gradeHistory.getYyyyq(), gradeHistory.getCourse(), gradeHistory.getInstructor(),
+                    gradeHistory.getGrade());
+            if (query.size() == 0) {
+                gradeHistory = gradeHistoryRepository.save(gradeHistory);
+                result.add(gradeHistory);
+            } else {
+                GradeHistory existing = query.get(0);
+                existing.setCount(gradeHistory.getCount());
+                existing = gradeHistoryRepository.save(existing);
+                result.add(existing);
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UploadGradeDataJobFactory.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UploadGradeDataJobFactory.java
@@ -1,0 +1,24 @@
+package edu.ucsb.cs156.courses.jobs;
+
+ import org.springframework.beans.factory.annotation.Autowired;
+ import org.springframework.stereotype.Service;
+
+ import edu.ucsb.cs156.courses.repositories.GradeHistoryRepository;
+ import edu.ucsb.cs156.courses.services.UCSBGradeHistoryService;
+ import lombok.extern.slf4j.Slf4j;
+
+ @Service
+ public class UploadGradeDataJobFactory {
+
+     @Autowired
+     UCSBGradeHistoryService ucsbGradeHistoryService;
+
+     @Autowired
+     GradeHistoryRepository gradeHistoryRepository;
+
+     public UploadGradeDataJob create() {
+         return new UploadGradeDataJob(
+                 ucsbGradeHistoryService,
+                 gradeHistoryRepository);
+     }
+ }

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UploadGradeDataJobFactoryTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UploadGradeDataJobFactoryTests.java
@@ -1,0 +1,39 @@
+package edu.ucsb.cs156.courses.jobs;
+
+ import static org.junit.jupiter.api.Assertions.assertEquals;
+
+ import org.junit.jupiter.api.Test;
+ import org.springframework.beans.factory.annotation.Autowired;
+ import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+ import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+ import org.springframework.boot.test.mock.mockito.MockBean;
+
+ import edu.ucsb.cs156.courses.repositories.GradeHistoryRepository;
+ import edu.ucsb.cs156.courses.services.UCSBGradeHistoryService;
+
+ @RestClientTest(UploadGradeDataJobFactory.class)
+ @AutoConfigureDataJpa
+ public class UploadGradeDataJobFactoryTests {
+
+     @MockBean
+     GradeHistoryRepository gradeHistoryRepository;
+
+     @MockBean
+     UCSBGradeHistoryService ucsbGradeHistoryService;
+
+     @Autowired
+     UploadGradeDataJobFactory UploadGradeDataJobFactory;
+
+     @Test
+     void test_create() throws Exception {
+
+         // Act
+
+         UploadGradeDataJob UploadGradeDataJob = UploadGradeDataJobFactory.create();
+
+         // Assert
+
+         assertEquals(ucsbGradeHistoryService,UploadGradeDataJob.getUcsbGradeHistoryService());
+         assertEquals(gradeHistoryRepository,UploadGradeDataJob.getGradeHistoryRepository());
+     }
+ }

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UploadGradeDataJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UploadGradeDataJobTests.java
@@ -1,0 +1,182 @@
+package edu.ucsb.cs156.courses.jobs;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+
+import edu.ucsb.cs156.courses.repositories.GradeHistoryRepository;
+import edu.ucsb.cs156.courses.entities.GradeHistory;
+import edu.ucsb.cs156.courses.entities.Job;
+import edu.ucsb.cs156.courses.services.UCSBGradeHistoryService;
+import edu.ucsb.cs156.courses.services.jobs.JobContext;
+
+@RestClientTest(UploadGradeDataJob.class)
+@AutoConfigureDataJpa
+public class UploadGradeDataJobTests {
+
+    @MockBean
+    GradeHistoryRepository gradeHistoryRepository;
+
+    @MockBean
+    UCSBGradeHistoryService ucsbGradeHistoryService;
+
+    @Test
+    public void test_upsertAll() {
+
+        // arrange
+
+        List<GradeHistory> gradeHistoriesToUpsert = new ArrayList<GradeHistory>();
+        GradeHistory existingOne = GradeHistory.builder()
+                .yyyyq("20204")
+                .course("CMPSC   156")
+                .instructor("CONRAD P")
+                .grade("A")
+                .count(50)
+                .build();
+        GradeHistory existingOneUpdated = GradeHistory.builder()
+                .yyyyq("20204")
+                .course("CMPSC   156")
+                .instructor("CONRAD P")
+                .grade("A")
+                .count(51)
+                .build();
+        GradeHistory newOne = GradeHistory.builder()
+                .yyyyq("20204")
+                .course("CMPSC   148")
+                .instructor("HOLLERER T")
+                .grade("A")
+                .count(50)
+                .build();
+
+        gradeHistoriesToUpsert.add(existingOneUpdated);
+        gradeHistoriesToUpsert.add(newOne);
+
+        when(gradeHistoryRepository.findByYyyyqAndCourseAndInstructorAndGrade(eq("20204"), eq("CMPSC   156"), eq("CONRAD P"), eq("A")))
+            .thenReturn(Arrays.asList(existingOne));
+
+        when(gradeHistoryRepository.findByYyyyqAndCourseAndInstructorAndGrade(eq("20204"), eq("CMPSC   148"), eq("HOLLERER T"), eq("A")))
+            .thenReturn(Arrays.asList());
+
+        when(gradeHistoryRepository.save(eq(existingOneUpdated)))
+            .thenReturn(existingOneUpdated);
+
+        when(gradeHistoryRepository.save(eq(newOne)))
+            .thenReturn(newOne);
+
+
+        // act
+
+        List<GradeHistory> result = UploadGradeDataJob.upsertAll(gradeHistoryRepository, gradeHistoriesToUpsert);
+
+        // assert
+
+        assertTrue(result.contains(existingOne));
+        assertTrue(result.contains(newOne));
+
+        verify(gradeHistoryRepository).findByYyyyqAndCourseAndInstructorAndGrade(eq("20204"), eq("CMPSC   156"), eq("CONRAD P"), eq("A"));
+        verify(gradeHistoryRepository).findByYyyyqAndCourseAndInstructorAndGrade(eq("20204"), eq("CMPSC   148"), eq("HOLLERER T"), eq("A"));
+        verify(gradeHistoryRepository).save(existingOneUpdated);
+        verify(gradeHistoryRepository).save(newOne);
+
+    }
+
+    @Test
+    void test_log_output_success() throws Exception {
+
+        // Arrange
+
+        Job jobStarted = Job.builder().build();
+        JobContext ctx = new JobContext(null, jobStarted);
+
+        UploadGradeDataJob uploadGradeDataJob = 
+            new UploadGradeDataJob(ucsbGradeHistoryService,
+                gradeHistoryRepository);
+
+        List<String> mockedListOfUrls = new ArrayList<String>();
+        mockedListOfUrls.add("https://raw.githubusercontent.com/ucsb-cs156/UCSB_Grades/main/quarters/F20/CMPSC.csv");
+        mockedListOfUrls.add("https://raw.githubusercontent.com/ucsb-cs156/UCSB_Grades/main/quarters/F20/CMPTGCS.csv");
+        mockedListOfUrls.add("https://raw.githubusercontent.com/ucsb-cs156/UCSB_Grades/main/quarters/W21/CMPSC.csv");
+        mockedListOfUrls.add("https://raw.githubusercontent.com/ucsb-cs156/UCSB_Grades/main/quarters/W21/CMPTGCS.csv");
+
+        List<GradeHistory> gradeHistory_F20_CMPSC = new ArrayList<GradeHistory>();
+        gradeHistory_F20_CMPSC.add(
+            GradeHistory.builder()
+                .yyyyq("20204")
+                .course("CMPSC   156")
+                .instructor("CONRAD P")
+                .grade("A")
+                .count(50)
+                .build()
+        );
+
+        List<GradeHistory> gradeHistory_F20_CMPTGCS = new ArrayList<GradeHistory>();
+        gradeHistory_F20_CMPTGCS.add(
+            GradeHistory.builder()
+                .yyyyq("20204")
+                .course("CMPTGCS   1A")
+                .instructor("WANG R K")
+                .grade("P")
+                .count(8)
+                .build()
+        );
+
+        List<GradeHistory> gradeHistory_W21_CMPSC = new ArrayList<GradeHistory>();
+        gradeHistory_W21_CMPSC.add(
+            GradeHistory.builder()
+                .yyyyq("20211")
+                .course("CMPSC   156")
+                .instructor("CONRAD P")
+                .grade("A")
+                .count(50)
+                .build()
+        );
+
+        List<GradeHistory> gradeHistory_W21_CMPTGCS = new ArrayList<GradeHistory>();
+        gradeHistory_W21_CMPTGCS.add(
+            GradeHistory.builder()
+                .yyyyq("20211")
+                .course("CMPTGCS  20")
+                .instructor("WANG R K")
+                .grade("P")
+                .count(8)
+                .build()
+        );
+
+        when(ucsbGradeHistoryService.getUrls()).thenReturn(mockedListOfUrls);
+        when(ucsbGradeHistoryService.getGradeData(eq(mockedListOfUrls.get(0)))).thenReturn(gradeHistory_F20_CMPSC);
+        when(ucsbGradeHistoryService.getGradeData(eq(mockedListOfUrls.get(1)))).thenReturn(gradeHistory_F20_CMPTGCS);
+        when(ucsbGradeHistoryService.getGradeData(eq(mockedListOfUrls.get(2)))).thenReturn(gradeHistory_W21_CMPSC);
+        when(ucsbGradeHistoryService.getGradeData(eq(mockedListOfUrls.get(3)))).thenReturn(gradeHistory_W21_CMPTGCS);
+
+        // Act
+
+        uploadGradeDataJob.accept(ctx);
+
+        // Assert
+
+        String expected = """
+            Updating UCSB Grade History Data
+            Processing data for year: 20204
+            Processing data for subjectArea: CMPSC
+            Processing data for subjectArea: CMPTGCS
+            Processing data for year: 20211
+            Processing data for subjectArea: CMPSC
+            Processing data for subjectArea: CMPTGCS
+            Finished updating UCSB Grade History Data""";
+
+        assertEquals(expected, jobStarted.getLog());
+    }
+}


### PR DESCRIPTION
In this PR, we created a job and job factory for the purpose of uploading multiple grade history data entries.

UploadGradeDataJob.java: uses data retrieved from Grade History Service,  through a GitHub Api call, to upload multiple data entries into the Grade History database.

UploadGradeDataJobFactory.java: class with method to create a UploadGradeDataJob object using UploadGradeDataJob constructor.