### PR TITLE
BUGFIX: Images don't show up reliably on localhost

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/FrontendProxyController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/FrontendProxyController.java
@@ -13,7 +13,7 @@ import java.net.ConnectException;
 @RestController
 public class FrontendProxyController {
   @GetMapping({"/", "/{path:^(?!api|oauth2|swagger-ui).*}/**"})
-  public ResponseEntity<String> proxy(ProxyExchange<String> proxy) {
+  public ResponseEntity<?> proxy(ProxyExchange<byte[]> proxy) {
     String path = proxy.path("/");
     try {
       return proxy.uri("http://localhost:3000/" + path).get();


### PR DESCRIPTION
In this PR, we fix the bug where static images do not always appear correctly on localhost, specifically localhost:8080. The proxy controller was casting the ResponseEntity from the frontend to a String, which resulted in images and possibly other media being null on localhost:8080. Following the [Spring documentation](https://cloud.spring.io/spring-cloud-gateway/multi/multi__building_a_simple_gateway_using_spring_mvc.html), we changed the casting to be a wildcard instead and made the parameter a byte array.

See:
https://github.com/ucsb-cs156-s23/proj-gauchoride-s23-5pm-3/pull/34
https://github.com/ucsb-cs156/proj-courses/issues/31

**Before**

<img width="768" alt="Screenshot 2023-06-06 at 11 40 01 AM" src="https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-1/assets/60124873/0bad4651-1332-4526-96dc-9aaf33acc048">

**After**

<img width="768" alt="Screenshot 2023-06-06 at 11 43 24 AM" src="https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-1/assets/60124873/9beb4e54-0fd7-44fe-833b-2c4075b8afe1">