### PR TITLE
REFACTOR: Replace logger with @Slf4j

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeController.java
@@ -6,8 +6,6 @@ import edu.ucsb.cs156.courses.collections.ConvertedSectionCollection;
 import edu.ucsb.cs156.courses.documents.ConvertedSection;
 import io.swagger.annotations.ApiOperation;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,9 +19,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @RestController
 @RequestMapping("/api/public/courseovertime")
 public class CourseOverTimeController {
-
-    private final Logger logger = LoggerFactory.getLogger(CourseOverTimeController.class);
-
     private ObjectMapper mapper = new ObjectMapper();
 
     @Autowired

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumController.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import org.springframework.http.ResponseEntity;
@@ -20,8 +18,6 @@ import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 @RestController
 @RequestMapping("/api/public")
 public class UCSBCurriculumController {
-    private final Logger logger = LoggerFactory.getLogger(UCSBCurriculumController.class);
-
     private ObjectMapper mapper = new ObjectMapper();
 
     @Autowired

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsController.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import org.springframework.http.ResponseEntity;
@@ -20,8 +18,6 @@ import edu.ucsb.cs156.courses.services.UCSBCurriculumService;
 @RestController
 @RequestMapping("/api/sections")
 public class UCSBSectionsController {
-    private final Logger logger = LoggerFactory.getLogger(UCSBSectionsController.class);
-
     private ObjectMapper mapper = new ObjectMapper();
 
     @Autowired

--- a/src/main/java/edu/ucsb/cs156/courses/documents/Course.java
+++ b/src/main/java/edu/ucsb/cs156/courses/documents/Course.java
@@ -3,8 +3,6 @@ package edu.ucsb.cs156.courses.documents;
 import java.util.List;
 import java.util.Objects;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import lombok.AllArgsConstructor;

--- a/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
+++ b/src/main/java/edu/ucsb/cs156/courses/services/UCSBCurriculumService.java
@@ -7,8 +7,6 @@ import java.util.List;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.client.RestTemplateBuilder;

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/CourseOverTimeControllerTests.java
@@ -3,8 +3,6 @@ package edu.ucsb.cs156.courses.controllers;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -35,7 +33,6 @@ import java.util.Arrays;
 @Import(SecurityConfig.class)
 @AutoConfigureDataJpa
 public class CourseOverTimeControllerTests {
-    private final Logger logger = LoggerFactory.getLogger(CourseOverTimeControllerTests.class);
     private ObjectMapper mapper = new ObjectMapper();
 
     @Autowired

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBCurriculumControllerTests.java
@@ -12,8 +12,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -29,7 +27,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @Import(SecurityConfig.class)
 @AutoConfigureDataJpa
 public class UCSBCurriculumControllerTests {
-    private final Logger logger = LoggerFactory.getLogger(UCSBCurriculumControllerTests.class);
     private ObjectMapper mapper = new ObjectMapper();
 
     @MockBean

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/UCSBSectionsControllerTests.java
@@ -12,8 +12,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -29,7 +27,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @Import(SecurityConfig.class)
 @AutoConfigureDataJpa
 public class UCSBSectionsControllerTests {
-    private final Logger logger = LoggerFactory.getLogger(UCSBSectionsControllerTests.class);
     private ObjectMapper mapper = new ObjectMapper();
 
     @MockBean


### PR DESCRIPTION
In this PR, we replace the old way of setting up `slf4j`:

```java
private final Logger logger = LoggerFactory.getLogger(CourseInstructorController.class);
```

...with the preferable Lombok annotation:

```java
@Slf4fj
```

Note: In our code, all instances of this line in our codebase were no longer being used. So this PR consists of only deletions.

See:
https://github.com/ucsb-cs156/proj-courses/issues/36