### PR TITLE
KD - Add placeholder 'Last Updated' page to admin dropdown

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,6 +3,7 @@ import CourseDescriptionIndexPage from "main/pages/CourseDescriptions/CourseDesc
 import ProfilePage from "main/pages/ProfilePage";
 import AdminUsersPage from "main/pages/AdminUsersPage";
 import AdminLoadSubjectsPage from "main/pages/AdminLoadSubjectsPage";
+import AdminLastUpdatedPage from "main/pages/AdminLastUpdatedPage";
 import AdminPersonalSchedulesPage from "main/pages/AdminPersonalSchedulePage";
 import AdminJobsPage from "main/pages/AdminJobsPage";
 
@@ -36,6 +37,7 @@ function App() {
             <>
               <Route exact path="/admin/users" element={<AdminUsersPage />} />
               <Route exact path="/admin/loadsubjects" element={<AdminLoadSubjectsPage />} />
+              <Route exact path="/admin/lastupdated" element={<AdminLastUpdatedPage />} />
               <Route exact path="/admin/personalschedule" element={<AdminPersonalSchedulesPage />} />
               <Route path="/admin/jobs" element={<AdminJobsPage />} />
             </>

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -92,6 +92,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                     <NavDropdown.Item href="/admin/users" data-testid="appnavbar-admin-users">Users</NavDropdown.Item>
                     <NavDropdown.Item href="/admin/personalschedule" data-testid="appnavbar-admin-personalschedule">Personal Schedules</NavDropdown.Item>
                     <NavDropdown.Item href="/admin/loadsubjects" data-testid="appnavbar-admin-loadsubjects">Load Subjects</NavDropdown.Item>
+                    <NavDropdown.Item href="/admin/lastupdated" data-testid="appnavbar-admin-lastupdated">Last Updated</NavDropdown.Item>
                     <NavDropdown.Item href="/admin/jobs" data-testid="appnavbar-admin-jobs">Manage Jobs</NavDropdown.Item>
                   </NavDropdown>
                 )

--- a/frontend/src/main/pages/AdminLastUpdatedPage.js
+++ b/frontend/src/main/pages/AdminLastUpdatedPage.js
@@ -1,0 +1,15 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function AdminLastUpdatedPage() {
+  return (
+    <BasicLayout>
+        <p>
+        When complete, this page will allow an admin to see when data for a quarter and subject area was last updated.
+        </p>      
+    </BasicLayout>
+  );
+};
+
+
+
+

--- a/frontend/src/stories/pages/AdminLastUpdatedPage.stories.js
+++ b/frontend/src/stories/pages/AdminLastUpdatedPage.stories.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import AdminLastUpdatedPage from "main/pages/AdminLastUpdatedPage";
+
+export default {
+    title: 'pages/AdminLastUpdatedPage',
+    component: AdminLastUpdatedPage
+};
+
+const Template = () => <AdminLastUpdatedPage />;
+
+export const Default = Template.bind({});
+

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -46,7 +46,8 @@ describe("AppNavbar tests", () => {
         aElement?.click();
 
         expect(await screen.findByTestId(/appnavbar-admin-users/)).toBeInTheDocument();
-        expect(screen.getByTestId("appnavbar-admin-loadsubjects")).toBeInTheDocument(); 
+        expect(screen.getByTestId("appnavbar-admin-loadsubjects")).toBeInTheDocument();
+        expect(screen.getByTestId("appnavbar-admin-lastupdated")).toBeInTheDocument();
         expect(screen.getByTestId(/appnavbar-admin-personalschedule/)).toBeInTheDocument();
     });
 

--- a/frontend/src/tests/pages/AdminLastUpdatedPage.test.js
+++ b/frontend/src/tests/pages/AdminLastUpdatedPage.test.js
@@ -1,0 +1,41 @@
+import { render} from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import AdminLastUpdatedPage from "main/pages/AdminLastUpdatedPage";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("AdminLastUpdatedPage tests", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("renders without crashing for admin user", () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminLastUpdatedPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+});


### PR DESCRIPTION
In this PR, I added a placeholder page for "Last Updated" to the admin dropdown, which we will populate in the future with information regarding when a subject area was last updated for a given quarter. In all, I have:

- Added the page option to the "Admin" dropdown (so this option is only viewable by admins)
- Configured the website to take you to a page containing some descriptive filler about what the page will contain in the future
- Added tests for the page

# Storybooks:

Before: None, new page
[After](https://ucsb-cs156-s23.github.io/proj-courses-s23-7pm-1/prs/63/storybook/?path=/docs/pages-adminlastupdatedpage--default)

[Before (Navbar)](https://ucsb-cs156-s23.github.io/proj-courses-s23-7pm-1/storybook/?path=/docs/components-nav-appnavbar--basic-not-logged-in)
[After (Navbar)](https://ucsb-cs156-s23.github.io/proj-courses-s23-7pm-1/prs/63/storybook/?path=/docs/components-nav-appnavbar--basic-not-logged-in)



# Screenshots:

Before:
![Screenshot 2023-06-06 at 21 34 36](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-1/assets/49664689/babba216-487a-4c34-8e16-69f4477a49b6)

After:

![Screenshot 2023-06-06 at 21 27 32](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-1/assets/49664689/c345052f-9eb0-438f-9550-06f5b935e85a)

![Screenshot 2023-06-06 at 21 30 53](https://github.com/ucsb-cs156-s23/proj-courses-s23-7pm-1/assets/49664689/d8159ce8-2c48-4dde-b756-b75c53f61950)

_Note: I have created this PR without adding live storybook links because storybook fails to compile for me, even on the main branch. Once this issue is resolved, I will append the before and after storybook links to this PR._



