### PR TITLE
Fixing a stupid error in the naming of the api params

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/SearchByInstructorController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/SearchByInstructorController.java
@@ -37,7 +37,7 @@ public class SearchByInstructorController {
     (
         @ApiParam
         (
-            name = "Start quarter",
+            name = "startQtr",
             required = true,
             value = "Quarter in YYYYQ format (1=Winter, 2=Spring, 3=Summer, 4=Fall)",
             example = "20202"
@@ -45,7 +45,7 @@ public class SearchByInstructorController {
         @RequestParam String startQtr,
         @ApiParam
         (
-            name =  "End quarter",
+            name =  "endQtr",
             required = true,
             value = "Quarter in YYYYQ format (1=Winter, 2=Spring, 3=Summer, 4=Fall)",
             example = "20232"
@@ -53,10 +53,10 @@ public class SearchByInstructorController {
         @RequestParam String endQtr,
         @ApiParam
         (
-            name = "Instructor name",
+            name = "instructor",
             required = true,
             value = "Instructor's name",
-            example = "'CONRAD'"
+            example = "'CONRAD'q"
         )
         @RequestParam String instructor
     ) 

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/SearchByInstructorController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/SearchByInstructorController.java
@@ -56,7 +56,7 @@ public class SearchByInstructorController {
             name = "instructor",
             required = true,
             value = "Instructor's name",
-            example = "'CONRAD'q"
+            example = "'CONRAD'"
         )
         @RequestParam String instructor
     ) 


### PR DESCRIPTION
In this PR I resolve an error I accidentally introduced to the final push to main. I changed the names of the api params for search instructor which broke the backend search.